### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,14 +39,12 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:image, :name, :text, :category_id, :status_id, :delivery_fee_id, :shipment_day_id,
                                  :prefectures_id, :price).merge(user_id: current_user.id)
   end
-  
+
   def find_params
     @item = Item.find(params[:id])
-  end  
+  end
 
   def move_to_index
     redirect_to root_path unless current_user == @item.user
   end
-
- 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :find_params, only: [:show, :edit, :update]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :find_params, except: [:index, :new, :create]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @item = Item.includes(:user).order('created_at DESC')
@@ -26,6 +26,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
       <% if current_user == @item.user %>
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:  "items#index"
-  resources :items, only:[:new, :create, :show, :edit, :update]
+  resources :items, only:[:new, :create, :show, :edit, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:  "items#index"
-  resources :items, only:[:new, :create, :show, :edit, :update, :destroy]
+  resources :items
 end


### PR DESCRIPTION
# What
itemsコントローラーにdestroyアクションの追加
商品詳細ページに削除機能の追加

# Why
商品削除機能実装のため

* ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/64e42201f579cc7131ff7dc2cacf34b4